### PR TITLE
Pin CodeQL GitHub Actions to specific commit SHAs

### DIFF
--- a/.github/workflows/tools_codeql.yml
+++ b/.github/workflows/tools_codeql.yml
@@ -57,7 +57,7 @@ jobs:
             # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       # Add any setup steps before running the `github/codeql-action/init` action.
       # This includes steps like installing compilers or runtimes (`actions/setup-node`
       # or others). This is typically only required for manual builds.
@@ -66,7 +66,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225  # v4.35.2
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -94,6 +94,6 @@ jobs:
           exit 1
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225  # v4.35.2
         with:
           category: "/language:${{matrix.language}}"


### PR DESCRIPTION
This PR updates the CodeQL GitHub Actions workflow by pinning all actions to specific commit SHAs.

### What Changed
- Replaced version tags (e.g. `@v2`, `@v3`) with exact commit SHA references for CodeQL actions.
- Ensured all CodeQL-related GitHub Actions are pinned to immutable versions.
- Standardized action versioning across the security scanning workflow.