### PR TITLE
Fix PHP-FPM listen directive to use correct socket configuration

### DIFF
--- a/conf/php-fpm/www.conf
+++ b/conf/php-fpm/www.conf
@@ -5,7 +5,7 @@ error_log = /proc/self/fd/2
 user = www-data
 group = www-data
 
-listen = nginx:9000
+listen = 9000
 
 pm = dynamic
 pm.max_children = 5


### PR DESCRIPTION
This PR fixes the PHP-FPM `listen` directive to use the correct socket configuration.

### What Changed
- Updated PHP-FPM configuration to use the correct `listen` value.
- Ensured PHP-FPM matches the expected socket path used by the web server.
- Fixed misalignment between PHP-FPM and web server configuration.