### PR TITLE
Fix ShellCheck SC2046 warnings in Dockerfile for php-fpm

### DIFF
--- a/docker/php-fpm/Dockerfile
+++ b/docker/php-fpm/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update \
 ############################
 # PHP extensions
 ############################
-RUN docker-php-ext-install -j$(nproc) gettext
+RUN docker-php-ext-install -j"$(nproc)" gettext
 
 ############################
 # Locale configuration


### PR DESCRIPTION
This PR fixes a ShellCheck SC2046 warning Dockerfile for php-fpm by correcting how command substitution is handled.

### What Changed
- Updated command substitution usage to avoid unintended word splitting.