### PR TITLE
Fix incorrect GitHub repository owner references

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You can find an overview [here](https://github.com/dwydler/LookingGlass/tree/cus
 ## Install Docker, download containers und configure Looking Glass
 1. This script will install docker and containerd:
   ```
-    curl https://raw.githubusercontent.com/dwydler/LookingGlass-Docker/master/misc/01-docker.io-installation.sh | bash
+    curl https://raw.githubusercontent.com/wydler/LookingGlass-Docker/master/misc/01-docker.io-installation.sh | bash
   ```
 2. For IPv6 support, edit the Docker daemon configuration file, located at /etc/docker/daemon.json. Configure the following parameters and run `systemctl restart docker.service` to restart docker:
   ```
@@ -39,7 +39,7 @@ You can find an overview [here](https://github.com/dwydler/LookingGlass/tree/cus
   ```
 3. Clone the repository to the correct folder for docker container:
   ```
-   git clone https://github.com/dwydler/LookingGlass-Docker.git /opt/containers/lookingglass
+   git clone https://github.com/wydler/LookingGlass-Docker.git /opt/containers/lookingglass
    git -C /opt/containers/lookingglass checkout $(git -C /opt/containers/lookingglass tag | tail -1)
   ```
 4. Make a copy of the file "lg.default.env" named ".env"

--- a/docker/ipref3/Dockerfile
+++ b/docker/ipref3/Dockerfile
@@ -9,8 +9,8 @@ FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a
 LABEL maintainer="Daniel Wydler" \
       org.opencontainers.image.authors="Daniel Wydler" \
       org.opencontainers.image.description="A user-friendly PHP Looking Glass - Reloaded" \
-      org.opencontainers.image.documentation="https://github.com/dwydler/LookingGlass-Docker/blob/master/README.md" \
-      org.opencontainers.image.source="https://github.com/dwydler/LookingGlass-Docker" \
+      org.opencontainers.image.documentation="https://github.com/wydler/LookingGlass-Docker/blob/master/README.md" \
+      org.opencontainers.image.source="https://github.com/wydler/LookingGlass-Docker" \
       org.opencontainers.image.title="lookingglass-iperf" \
       org.opencontainers.image.url="https://hub.docker.com/r/wydler/lookingglass-iperf"
 

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -9,8 +9,8 @@ FROM nginx:1.30.0@sha256:1a9ab83e2892b75773978e8d91f42a7a2a0d8bb704959a51ff17c03
 LABEL maintainer="Daniel Wydler" \
       org.opencontainers.image.authors="Daniel Wydler" \
       org.opencontainers.image.description="A user-friendly PHP Looking Glass - Reloaded" \
-      org.opencontainers.image.documentation="https://github.com/dwydler/LookingGlass-Docker/blob/master/README.md" \
-      org.opencontainers.image.source="https://github.com/dwydler/LookingGlass-Docker" \
+      org.opencontainers.image.documentation="https://github.com/wydler/LookingGlass-Docker/blob/master/README.md" \
+      org.opencontainers.image.source="https://github.com/wydler/LookingGlass-Docker" \
       org.opencontainers.image.title="lookingglass-web" \
       org.opencontainers.image.url="https://hub.docker.com/r/wydler/lookingglass-web"
 

--- a/docker/php-fpm/Dockerfile
+++ b/docker/php-fpm/Dockerfile
@@ -9,8 +9,8 @@ FROM php:8.4.20-fpm@sha256:eec2a132b91271dcf51e86119311ec4b22105736af704997a6905
 LABEL maintainer="Daniel Wydler" \
       org.opencontainers.image.authors="Daniel Wydler" \
       org.opencontainers.image.description="A user-friendly PHP Looking Glass - Reloaded" \
-      org.opencontainers.image.documentation="https://github.com/dwydler/LookingGlass-Docker/blob/master/README.md" \
-      org.opencontainers.image.source="https://github.com/dwydler/LookingGlass-Docker" \
+      org.opencontainers.image.documentation="https://github.com/wydler/LookingGlass-Docker/blob/master/README.md" \
+      org.opencontainers.image.source="https://github.com/wydler/LookingGlass-Docker" \
       org.opencontainers.image.title="lookingglass-php" \
       org.opencontainers.image.url="https://hub.docker.com/r/wydler/lookingglass-php"
 


### PR DESCRIPTION
This PR fixes incorrect GitHub repository owner references in the project configuration.

### 🔧 What Changed
- Updated references pointing to the wrong GitHub owner/namespace.
- Corrected repository URLs and/or image references to use the proper owner.
- Ensured consistency across all GitHub-related configurations.
